### PR TITLE
Modify MetricsStormHooks class to be compliant with Storm 0.8.2 hooks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "1.9.1" % "test",
 resolvers ++= Seq("clojars" at "http://clojars.org/repo/",
                   "clojure-releases" at "http://build.clojure.org/releases")
 
-libraryDependencies += "storm" % "storm" % "0.8.1"
+libraryDependencies += "storm" % "storm" % "0.8.2"
 
 // Testing deps
 libraryDependencies ++= Seq()

--- a/src/ooyala/common/metrics_storm/MetricsStormHooks.scala
+++ b/src/ooyala/common/metrics_storm/MetricsStormHooks.scala
@@ -2,7 +2,7 @@ package ooyala.common.metrics_storm
 
 import backtype.storm.hooks.info._
 
-import backtype.storm.hooks.ITaskHook
+import backtype.storm.hooks._
 import backtype.storm.task.TopologyContext
 import backtype.storm.hooks.info._
 import com.yammer.metrics.Metrics
@@ -14,31 +14,29 @@ import com.yammer.metrics.Metrics
  * Add using the topology.auto.task.hooks config in Storm.
  * This class must have a zero-arg constructor.
  */
-class MetricsStormHooks extends ITaskHook {
-  def prepare(config: java.util.Map[_, _], context: TopologyContext) {
+class MetricsStormHooks extends BaseTaskHook {
+  override def prepare(config: java.util.Map[_, _], context: TopologyContext) {
     MetricsStorm.initWebConsoleFromTask(config, context)
     MetricsStorm.setupTaskMetrics(context)
   }
 
-  def cleanup() {
+  override def cleanup() {
     MetricsStorm.stopWebConsole()
     Metrics.shutdown()
   }
 
-  def emit(emitData: EmitInfo) {
+  override def emit(emitData: EmitInfo) {
     MetricsStorm.emitMeters.get(emitData.taskId) foreach { _.mark }
   }
 
-  def spoutAck(ackData: SpoutAckInfo) {}
+  override def spoutAck(ackData: SpoutAckInfo) {}
 
-  def spoutFail(failData: SpoutFailInfo) {}
+  override def spoutFail(failData: SpoutFailInfo) {}  
 
-  def error(error: Throwable) {}
-
-  def boltAck(ackData: BoltAckInfo) {
+  override def boltAck(ackData: BoltAckInfo) {
     val taskId = ackData.ackingTaskId
     MetricsStorm.ackMeters.get(taskId) foreach { meter => meter.mark() }
   }
 
-  def boltFail(failData: BoltFailInfo) {}
+  override def boltFail(failData: BoltFailInfo) {}
 }


### PR DESCRIPTION
Simple update to MetricsStormHooks to use BaseTaskHook instead of implement the ITaskHook class.
